### PR TITLE
feat: support HotChocolate 16

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,10 +1,21 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <HotChocolateVersion>15.0.0</HotChocolateVersion>
+    <HotChocolateVersion>16.0.7</HotChocolateVersion>
   </PropertyGroup>
   <ItemGroup>
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageVersion>
+    <PackageVersion Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageVersion>
     <PackageVersion Include="SensitiveString" Version="0.1.5" />
+    <PackageVersion Include="HotChocolate" Version="$(HotChocolateVersion)" />
     <PackageVersion Include="HotChocolate.Data" Version="$(HotChocolateVersion)" />
     <PackageVersion Include="HotChocolate.Diagnostics" Version="$(HotChocolateVersion)" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <HotChocolateVersion>16.0.7</HotChocolateVersion>
+    <HotChocolateVersion>16.0.0</HotChocolateVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />

--- a/SensitiveString.HotChocolate.sln
+++ b/SensitiveString.HotChocolate.sln
@@ -6,23 +6,63 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{21EB174C-CED
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TextPrivacy.SensitiveString.HotChocolate.Examples", "src\TextPrivacy.SensitiveString.HotChocolate.Examples\TextPrivacy.SensitiveString.HotChocolate.Examples.csproj", "{D9513782-056F-4A90-8DC4-986DB0B4D492}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{0C88DD14-F956-CE84-757C-A364CCF449FC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TextPrivacy.SensitiveString.HotChocolate.Tests", "test\TextPrivacy.SensitiveString.HotChocolate.Tests\TextPrivacy.SensitiveString.HotChocolate.Tests.csproj", "{8BD01461-B551-4CEB-B3D0-638A889EED40}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{EA5EA98A-75F8-422F-8858-F9857075584E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{EA5EA98A-75F8-422F-8858-F9857075584E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EA5EA98A-75F8-422F-8858-F9857075584E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{EA5EA98A-75F8-422F-8858-F9857075584E}.Debug|x64.Build.0 = Debug|Any CPU
+		{EA5EA98A-75F8-422F-8858-F9857075584E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{EA5EA98A-75F8-422F-8858-F9857075584E}.Debug|x86.Build.0 = Debug|Any CPU
 		{EA5EA98A-75F8-422F-8858-F9857075584E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EA5EA98A-75F8-422F-8858-F9857075584E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EA5EA98A-75F8-422F-8858-F9857075584E}.Release|x64.ActiveCfg = Release|Any CPU
+		{EA5EA98A-75F8-422F-8858-F9857075584E}.Release|x64.Build.0 = Release|Any CPU
+		{EA5EA98A-75F8-422F-8858-F9857075584E}.Release|x86.ActiveCfg = Release|Any CPU
+		{EA5EA98A-75F8-422F-8858-F9857075584E}.Release|x86.Build.0 = Release|Any CPU
 		{D9513782-056F-4A90-8DC4-986DB0B4D492}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D9513782-056F-4A90-8DC4-986DB0B4D492}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D9513782-056F-4A90-8DC4-986DB0B4D492}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D9513782-056F-4A90-8DC4-986DB0B4D492}.Debug|x64.Build.0 = Debug|Any CPU
+		{D9513782-056F-4A90-8DC4-986DB0B4D492}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D9513782-056F-4A90-8DC4-986DB0B4D492}.Debug|x86.Build.0 = Debug|Any CPU
 		{D9513782-056F-4A90-8DC4-986DB0B4D492}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D9513782-056F-4A90-8DC4-986DB0B4D492}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D9513782-056F-4A90-8DC4-986DB0B4D492}.Release|x64.ActiveCfg = Release|Any CPU
+		{D9513782-056F-4A90-8DC4-986DB0B4D492}.Release|x64.Build.0 = Release|Any CPU
+		{D9513782-056F-4A90-8DC4-986DB0B4D492}.Release|x86.ActiveCfg = Release|Any CPU
+		{D9513782-056F-4A90-8DC4-986DB0B4D492}.Release|x86.Build.0 = Release|Any CPU
+		{8BD01461-B551-4CEB-B3D0-638A889EED40}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8BD01461-B551-4CEB-B3D0-638A889EED40}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8BD01461-B551-4CEB-B3D0-638A889EED40}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8BD01461-B551-4CEB-B3D0-638A889EED40}.Debug|x64.Build.0 = Debug|Any CPU
+		{8BD01461-B551-4CEB-B3D0-638A889EED40}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8BD01461-B551-4CEB-B3D0-638A889EED40}.Debug|x86.Build.0 = Debug|Any CPU
+		{8BD01461-B551-4CEB-B3D0-638A889EED40}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8BD01461-B551-4CEB-B3D0-638A889EED40}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8BD01461-B551-4CEB-B3D0-638A889EED40}.Release|x64.ActiveCfg = Release|Any CPU
+		{8BD01461-B551-4CEB-B3D0-638A889EED40}.Release|x64.Build.0 = Release|Any CPU
+		{8BD01461-B551-4CEB-B3D0-638A889EED40}.Release|x86.ActiveCfg = Release|Any CPU
+		{8BD01461-B551-4CEB-B3D0-638A889EED40}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{EA5EA98A-75F8-422F-8858-F9857075584E} = {21EB174C-CED8-40DB-AD4E-E3BF9D9D3EC7}
 		{D9513782-056F-4A90-8DC4-986DB0B4D492} = {21EB174C-CED8-40DB-AD4E-E3BF9D9D3EC7}
+		{8BD01461-B551-4CEB-B3D0-638A889EED40} = {0C88DD14-F956-CE84-757C-A364CCF449FC}
 	EndGlobalSection
 EndGlobal

--- a/test/TextPrivacy.SensitiveString.HotChocolate.Tests/CursorKeySerializerTests.cs
+++ b/test/TextPrivacy.SensitiveString.HotChocolate.Tests/CursorKeySerializerTests.cs
@@ -1,0 +1,67 @@
+using TextPrivacy.SensitiveString;
+using TextPrivacy.SensitiveString.HotChocolate;
+using Xunit;
+
+namespace TextPrivacy.SensitiveString.HotChocolate.Tests;
+
+public class CursorKeySerializerTests
+{
+    [Fact]
+    public void SensitiveStringSerializer_IsSupported_OnlyForSensitiveString()
+    {
+        var serializer = new SensitiveStringCursorKeySerializer();
+
+        Assert.True(serializer.IsSupported(typeof(SensitiveString)));
+        Assert.False(serializer.IsSupported(typeof(SensitiveEmail)));
+        Assert.False(serializer.IsSupported(typeof(string)));
+    }
+
+    [Fact]
+    public void SensitiveEmailSerializer_IsSupported_OnlyForSensitiveEmail()
+    {
+        var serializer = new SensitiveEmailCursorKeySerializer();
+
+        Assert.True(serializer.IsSupported(typeof(SensitiveEmail)));
+        Assert.False(serializer.IsSupported(typeof(SensitiveString)));
+    }
+
+    [Fact]
+    public void SensitiveStringSerializer_GetCompareToMethod_IsNotNull()
+    {
+        var serializer = new SensitiveStringCursorKeySerializer();
+
+        Assert.NotNull(serializer.GetCompareToMethod(typeof(SensitiveString)));
+    }
+
+    [Fact]
+    public void SensitiveStringSerializer_FormatThenParse_RoundTrips()
+    {
+        var serializer = new SensitiveStringCursorKeySerializer();
+        var original = "Ada Lovelace".AsSensitive();
+
+        var buffer = new byte[256];
+        var formatted = serializer.TryFormat(original, buffer, out var written);
+
+        Assert.True(formatted);
+
+        var parsed = (SensitiveString) serializer.Parse(buffer.AsSpan(0, written));
+
+        Assert.Equal(original.Reveal(), parsed.Reveal());
+    }
+
+    [Fact]
+    public void SensitiveEmailSerializer_FormatThenParse_RoundTrips()
+    {
+        var serializer = new SensitiveEmailCursorKeySerializer();
+        var original = "ada@example.com".AsSensitiveEmail();
+
+        var buffer = new byte[256];
+        var formatted = serializer.TryFormat(original, buffer, out var written);
+
+        Assert.True(formatted);
+
+        var parsed = (SensitiveString) serializer.Parse(buffer.AsSpan(0, written));
+
+        Assert.Equal(original.Reveal(), parsed.Reveal());
+    }
+}

--- a/test/TextPrivacy.SensitiveString.HotChocolate.Tests/PagingIntegrationTests.cs
+++ b/test/TextPrivacy.SensitiveString.HotChocolate.Tests/PagingIntegrationTests.cs
@@ -1,0 +1,109 @@
+using HotChocolate;
+using HotChocolate.Data;
+using HotChocolate.Execution;
+using HotChocolate.Types;
+using Microsoft.Extensions.DependencyInjection;
+using TextPrivacy.SensitiveString;
+using TextPrivacy.SensitiveString.HotChocolate;
+using Xunit;
+
+namespace TextPrivacy.SensitiveString.HotChocolate.Tests;
+
+public class PagingIntegrationTests
+{
+    private static async Task<IRequestExecutor> BuildExecutorAsync() =>
+        await new ServiceCollection()
+            .AddGraphQL()
+            .AddSensitiveStringSupport()
+            .AddFiltering(c => c.AddDefaults().AddSensitiveStringSupport())
+            .AddSorting(c => c.AddDefaults().AddSensitiveStringSupport())
+            .AddQueryType<Query>()
+            .BuildRequestExecutorAsync();
+
+    [Fact]
+    public async Task Schema_BuildsWithSensitiveStringSupport()
+    {
+        var executor = await BuildExecutorAsync();
+
+        Assert.NotNull(executor.Schema);
+    }
+
+    // Reproduces the admin-list scenario: cursor paging while sorting by a SensitiveString
+    // field forces HotChocolate to encode the sort key into the cursor via the registered
+    // ICursorKeySerializer. On HotChocolate 15 this path crashed; it must succeed on 16.
+    [Fact]
+    public async Task Paging_SortedBySensitiveStringKey_ProducesCursorsWithoutErrors()
+    {
+        var executor = await BuildExecutorAsync();
+
+        var result = await executor.ExecuteAsync(
+            """
+            {
+              people(first: 1, order: { name: ASC }) {
+                nodes { id }
+                pageInfo { endCursor hasNextPage }
+              }
+            }
+            """);
+
+        var operationResult = result.ExpectOperationResult();
+
+        AssertNoErrors(operationResult.Errors);
+        AssertNonNullEndCursor(result);
+    }
+
+    [Fact]
+    public async Task Paging_SortedBySensitiveEmailKey_ProducesCursorsWithoutErrors()
+    {
+        var executor = await BuildExecutorAsync();
+
+        var result = await executor.ExecuteAsync(
+            """
+            {
+              people(first: 1, order: { email: ASC }) {
+                nodes { id }
+                pageInfo { endCursor hasNextPage }
+              }
+            }
+            """);
+
+        var operationResult = result.ExpectOperationResult();
+
+        AssertNoErrors(operationResult.Errors);
+        AssertNonNullEndCursor(result);
+    }
+
+    private static void AssertNoErrors(IReadOnlyList<IError>? errors) =>
+        Assert.True(
+            errors is null || errors.Count == 0,
+            $"Expected no GraphQL errors but got: {(errors is null ? "<null>" : string.Join("; ", errors.Select(e => e.Message)))}");
+
+    // A non-null endCursor proves HotChocolate encoded the SensitiveString sort key into a
+    // cursor via the registered ICursorKeySerializer — the exact path that failed on HC15.
+    private static void AssertNonNullEndCursor(IExecutionResult result)
+    {
+        var json = result.ToJson();
+        Assert.Contains("\"endCursor\"", json);
+        Assert.DoesNotMatch("\"endCursor\"\\s*:\\s*null", json);
+    }
+
+    public class Query
+    {
+        [UsePaging]
+        [UseSorting]
+        public IQueryable<Person> GetPeople() =>
+            new[]
+            {
+                new Person { Id = 1, Name = "Charlie".AsSensitive(), Email = "charlie@example.com".AsSensitiveEmail() },
+                new Person { Id = 2, Name = "Ada".AsSensitive(), Email = "ada@example.com".AsSensitiveEmail() },
+                new Person { Id = 3, Name = "Bob".AsSensitive(), Email = "bob@example.com".AsSensitiveEmail() },
+            }.AsQueryable();
+    }
+
+    public class Person
+    {
+        public int Id { get; set; }
+        public SensitiveString Name { get; set; } = string.Empty.AsSensitive();
+        public SensitiveEmail Email { get; set; } = "x@example.com".AsSensitiveEmail();
+    }
+}

--- a/test/TextPrivacy.SensitiveString.HotChocolate.Tests/PagingIntegrationTests.cs
+++ b/test/TextPrivacy.SensitiveString.HotChocolate.Tests/PagingIntegrationTests.cs
@@ -28,9 +28,8 @@ public class PagingIntegrationTests
         Assert.NotNull(executor.Schema);
     }
 
-    // Reproduces the admin-list scenario: cursor paging while sorting by a SensitiveString
-    // field forces HotChocolate to encode the sort key into the cursor via the registered
-    // ICursorKeySerializer. On HotChocolate 15 this path crashed; it must succeed on 16.
+    // Cursor paging while sorting by a SensitiveString field forces HotChocolate to encode
+    // the sort key into the cursor via the registered ICursorKeySerializer.
     [Fact]
     public async Task Paging_SortedBySensitiveStringKey_ProducesCursorsWithoutErrors()
     {

--- a/test/TextPrivacy.SensitiveString.HotChocolate.Tests/TextPrivacy.SensitiveString.HotChocolate.Tests.csproj
+++ b/test/TextPrivacy.SensitiveString.HotChocolate.Tests/TextPrivacy.SensitiveString.HotChocolate.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio" />
+        <PackageReference Include="coverlet.collector" />
+        <PackageReference Include="HotChocolate" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\TextPrivacy.SensitiveString.HotChocolate\TextPrivacy.SensitiveString.HotChocolate.csproj" />
+    </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Bump HotChocolate dependency 15.0.0 -> 16.0.7. The integration code compiles unchanged against HC16 (cursor key serializers, runtime type bindings, filtering/sorting conventions all still apply).

Add a test project covering the cursor key serializers (format/parse round-trip, type support) and an integration test that paginates while sorting by a SensitiveString / SensitiveEmail key — the keyset cursor path that must encode the sensitive sort key into the cursor. Green on net8.0 and net9.0.